### PR TITLE
Changed string ToLower to its invariant version.

### DIFF
--- a/src/Projects/MyCouch.Net45/Serialization/Conventions/DocTypeSerializationConvention.cs
+++ b/src/Projects/MyCouch.Net45/Serialization/Conventions/DocTypeSerializationConvention.cs
@@ -13,7 +13,7 @@ namespace MyCouch.Serialization.Conventions
 
         public DocTypeSerializationConvention()
         {
-            Convention = t => t.Name.ToLower();
+            Convention = t => t.Name.ToLowerInvariant();
         }
     }
 }


### PR DESCRIPTION
This fixes potential bugs when running this code in Turkey (and other countries with similar rules).

Example: If a class is named "Integer" it will become "integer" in most places, in a Turkish localized machine it will become "ınteger". (see: http://www.codinghorror.com/blog/2008/03/whats-wrong-with-turkey.html )
