### PR TITLE
Add Batch property to PUT / POST request objects.

### DIFF
--- a/src/Projects/MyCouch.Net45/Requests/Factories/DocumentHttpRequestFactoryBase.cs
+++ b/src/Projects/MyCouch.Net45/Requests/Factories/DocumentHttpRequestFactoryBase.cs
@@ -1,15 +1,27 @@
-﻿namespace MyCouch.Requests.Factories
+﻿using System.Collections.Generic;
+namespace MyCouch.Requests.Factories
 {
     public abstract class DocumentHttpRequestFactoryBase : HttpRequestFactoryBase
     {
         protected DocumentHttpRequestFactoryBase(IConnection connection) : base(connection) {}
 
-        protected virtual string GenerateRequestUrl(string id = null, string rev = null)
+        protected virtual string GenerateRequestUrl(string id = null, string rev = null, bool batch = false)
         {
+            var queryParameters = new List<string>();
+            if (rev != null)
+            {
+                queryParameters.Add(string.Format("rev={0}", rev));
+            }
+            if (batch)
+            {
+                queryParameters.Add("batch=ok");
+            }
+            var queryParametersForURI = string.Join("&", queryParameters);
+
             return string.Format("{0}/{1}{2}",
                 Connection.Address,
                 id ?? string.Empty,
-                rev == null ? string.Empty : string.Concat("?rev=", rev));
+                string.IsNullOrEmpty(queryParametersForURI) ? "" : "?" + queryParametersForURI);
         }
     }
 }

--- a/src/Projects/MyCouch.Net45/Requests/Factories/PostDocumentHttpRequestFactory.cs
+++ b/src/Projects/MyCouch.Net45/Requests/Factories/PostDocumentHttpRequestFactory.cs
@@ -9,7 +9,7 @@ namespace MyCouch.Requests.Factories
 
         public virtual HttpRequest Create(PostDocumentRequest request)
         {
-            var httpRequest = CreateFor<PostDocumentRequest>(HttpMethod.Post, GenerateRequestUrl());
+            var httpRequest = CreateFor<PostDocumentRequest>(HttpMethod.Post, GenerateRequestUrl(batch: request.Batch));
 
             httpRequest.SetContent(request.Content);
 

--- a/src/Projects/MyCouch.Net45/Requests/Factories/PutDocumentHttpRequestFactory.cs
+++ b/src/Projects/MyCouch.Net45/Requests/Factories/PutDocumentHttpRequestFactory.cs
@@ -9,7 +9,7 @@ namespace MyCouch.Requests.Factories
 
         public virtual HttpRequest Create(PutDocumentRequest request)
         {
-            var httpRequest = CreateFor<PutDocumentRequest>(HttpMethod.Put, GenerateRequestUrl(request.Id, request.Rev));
+            var httpRequest = CreateFor<PutDocumentRequest>(HttpMethod.Put, GenerateRequestUrl(request.Id, request.Rev, request.Batch));
 
             httpRequest.SetIfMatch(request.Rev);
             httpRequest.SetContent(request.Content);

--- a/src/Projects/MyCouch.Net45/Requests/PostDocumentRequest.cs
+++ b/src/Projects/MyCouch.Net45/Requests/PostDocumentRequest.cs
@@ -8,6 +8,7 @@ namespace MyCouch.Requests
 #endif
     public class PostDocumentRequest : Request
     {
+        public bool Batch { get; set; }
         public string Content { get; set; }
 
         public PostDocumentRequest(string content)

--- a/src/Projects/MyCouch.Net45/Requests/PutDocumentRequest.cs
+++ b/src/Projects/MyCouch.Net45/Requests/PutDocumentRequest.cs
@@ -11,6 +11,7 @@ namespace MyCouch.Requests
         public string Id { get; private set; }
         public string Rev { get; private set; }
         public string Content { get; set; }
+        public bool Batch { get; set; }
 
         public PutDocumentRequest(string id, string rev, string content)
             : this(id, content)

--- a/src/Tests/MyCouch.Net45.IntegrationTests/ClientTests/DocumentsTests.cs
+++ b/src/Tests/MyCouch.Net45.IntegrationTests/ClientTests/DocumentsTests.cs
@@ -3,6 +3,8 @@ using FluentAssertions;
 using MyCouch.Testing;
 using MyCouch.Testing.TestData;
 using Xunit;
+using MyCouch.Requests;
+using System.Net;
 
 namespace MyCouch.IntegrationTests.ClientTests
 {
@@ -60,11 +62,29 @@ namespace MyCouch.IntegrationTests.ClientTests
         }
 
         [Fact]
+        public void When_post_of_new_document_in_batch_mode_The_document_is_persisted()
+        {
+            var request = new PostDocumentRequest(ClientTestData.Artists.Artist1Json) { Batch = true };
+            var response = SUT.PostAsync(request).Result;
+
+            response.Should().BeSuccessfulBatchPost(ClientTestData.Artists.Artist1Id);
+        }
+
+        [Fact]
         public void When_put_of_new_document_The_document_is_replaced()
         {
             var response = SUT.PutAsync(ClientTestData.Artists.Artist1Id, ClientTestData.Artists.Artist1Json).Result;
 
             response.Should().BeSuccessfulPutOfNew(ClientTestData.Artists.Artist1Id);
+        }
+
+        [Fact]
+        public void When_put_of_new_document_in_batch_mode_The_document_is_replaced()
+        {
+            var request = new PutDocumentRequest(ClientTestData.Artists.Artist1Id, ClientTestData.Artists.Artist1Json) { Batch = true };
+            var response = SUT.PutAsync(request).Result;
+
+            response.Should().BeSuccessfulBatchPutOfNew(ClientTestData.Artists.Artist1Id);
         }
         
         [Fact]
@@ -76,6 +96,18 @@ namespace MyCouch.IntegrationTests.ClientTests
             var response = SUT.PutAsync(getResponse.Id, getResponse.Content).Result;
 
             response.Should().BeSuccessfulPut(ClientTestData.Artists.Artist1Id);
+        }
+
+        [Fact]
+        public void Can_put_of_existing_document_in_batch_mode()
+        {
+            var postResponse = SUT.PostAsync(ClientTestData.Artists.Artist1Json).Result;
+            var getResponse = SUT.GetAsync(postResponse.Id).Result;
+
+            var updateRequest = new PutDocumentRequest(getResponse.Id, getResponse.Content) { Batch = true };
+            var response = SUT.PutAsync(updateRequest).Result;
+
+            response.Should().BeSuccessfulBatchPut(ClientTestData.Artists.Artist1Id);
         }
 
         [Fact]

--- a/src/Tests/MyCouch.Net45.Testing/Shoulds.cs
+++ b/src/Tests/MyCouch.Net45.Testing/Shoulds.cs
@@ -384,6 +384,16 @@ namespace MyCouch.Testing
             Response.Rev.Should().NotBeNullOrEmpty();
         }
 
+        public void BeSuccessfulBatchPost(string initialId)
+        {
+            Response.RequestMethod.Should().Be(HttpMethod.Post);
+            Response.IsSuccess.Should().BeTrue();
+            Response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+            Response.Error.Should().BeNull();
+            Response.Reason.Should().BeNull();
+            Response.Id.Should().Be(initialId);
+        }
+
         public void BeSuccessfulPut(string initialId)
         {
             Response.RequestMethod.Should().Be(HttpMethod.Put);
@@ -393,6 +403,16 @@ namespace MyCouch.Testing
             Response.Reason.Should().BeNull();
             Response.Id.Should().Be(initialId);
             Response.Rev.Should().NotBeNullOrEmpty();
+        }
+
+        public void BeSuccessfulBatchPut(string initialId)
+        {
+            Response.RequestMethod.Should().Be(HttpMethod.Put);
+            Response.IsSuccess.Should().BeTrue();
+            Response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+            Response.Error.Should().BeNull();
+            Response.Reason.Should().BeNull();
+            Response.Id.Should().Be(initialId);
         }
 
         public void Be409Put(string initialId)
@@ -416,6 +436,17 @@ namespace MyCouch.Testing
             Response.Id.Should().NotBeNullOrEmpty();
             Response.Id.Should().Be(initialId);
             Response.Rev.Should().NotBeNullOrEmpty();
+        }
+
+        public void BeSuccessfulBatchPutOfNew(string initialId)
+        {
+            Response.RequestMethod.Should().Be(HttpMethod.Put);
+            Response.IsSuccess.Should().BeTrue();
+            Response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+            Response.Error.Should().BeNull();
+            Response.Reason.Should().BeNull();
+            Response.Id.Should().NotBeNullOrEmpty();
+            Response.Id.Should().Be(initialId);
         }
 
         public void BeSuccessfulDelete(string initialId)


### PR DESCRIPTION
When specifying the Batch property, batch=ok is passed as a parameter
to the CouchDB / Cloudant API.

Given that this is rarely used, it's not exposed in the document PUT /
POST helper methods - you have to construct the request objects fully in
order to use it.
