### PR TITLE
Drilldown changes

### DIFF
--- a/source/tests/MyCouch.IntegrationTests.Net40/MyCouch.IntegrationTests.Net40.csproj
+++ b/source/tests/MyCouch.IntegrationTests.Net40/MyCouch.IntegrationTests.Net40.csproj
@@ -183,9 +183,6 @@
       <Name>MyCouch.Testing.Net40</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/source/tests/MyCouch.IntegrationTests.Net45/MyCouch.IntegrationTests.Net45.csproj
+++ b/source/tests/MyCouch.IntegrationTests.Net45/MyCouch.IntegrationTests.Net45.csproj
@@ -111,9 +111,6 @@
       <Name>MyCouch.Testing.Net45</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Added a few changes in code & tests for drill down feature.
I somehow end up adding an entry <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" /> to the integration test project inadvertently. Is there something to be careful to avoid it? It's there in this changeset too, so please undo it.

Another question, cloudant search doc on drilldown (https://docs.cloudant.com/api/search.html) says that this can be specified multiple times, whereas query doesn't seem to support it (its a query param so only a single entry of name:value can go in as the value type seems to be a 2 valued JSON array). Any ideas? For now, the code appends a single drilldown at a time.
