### PR TITLE
Add the ability to track the exception details

### DIFF
--- a/source/projects/MyCouch.Net45/MyCouchResponseException.cs
+++ b/source/projects/MyCouch.Net45/MyCouchResponseException.cs
@@ -28,7 +28,11 @@ namespace MyCouch
                 uri,
                 error,
                 reason))
-        { }
+        {
+            this.HttpStatus = httpStatus;
+            this.Error = error;
+            this.Reason = reason;
+        }
 
 #if !PCL
         protected MyCouchResponseException(SerializationInfo info, StreamingContext context)


### PR DESCRIPTION
Hi Daniel,

Please consider my small change to allow processing the failed response details without the need to parse the exception message directly. Many thanks in advance!

Cheers,

Jan Ambroz
