### PR TITLE
Allow derived classes to override CreateHttpClient

### DIFF
--- a/source/projects/MyCouch/Net/Connection.cs
+++ b/source/projects/MyCouch/Net/Connection.cs
@@ -55,7 +55,7 @@ namespace MyCouch.Net
                 throw new ObjectDisposedException(GetType().Name);
         }
 
-        protected HttpClient CreateHttpClient(ConnectionInfo connectionInfo)
+        protected virtual HttpClient CreateHttpClient(ConnectionInfo connectionInfo)
         {
             var handler = new HttpClientHandler
             {


### PR DESCRIPTION
In order to create a customized HttpClient with a different HttpClientHandler to allow, for instance, proxy configuration.