### PR TITLE
Fix Query class when CustomQueryParameters set

### DIFF
--- a/source/projects/MyCouch/Query.cs
+++ b/source/projects/MyCouch/Query.cs
@@ -201,7 +201,11 @@ namespace MyCouch
         /// <summary>
         /// Additional custom query string parameters.
         /// </summary>
-        public IDictionary<string, object> CustomQueryParameters { get; set; }
+        public IDictionary<string, object> CustomQueryParameters
+        {
+            get { return State.CustomQueryParameters; }
+            set { State.CustomQueryParameters = value; }
+        }
 
         /// <summary>
         /// Indicates if there are any <see cref="CustomQueryParameters"/> or not.

--- a/source/tests/MyCouch.IntegrationTests/CoreTests/MyCouchStoreQueryTests.cs
+++ b/source/tests/MyCouch.IntegrationTests/CoreTests/MyCouchStoreQueryTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using MyCouch.IntegrationTests.TestFixtures;
@@ -544,6 +545,26 @@ namespace MyCouch.IntegrationTests.CoreTests
                 .ToArray();
 
             values.ShouldBeEquivalentTo(ArtistsById);
+        }
+
+
+        [MyFact(TestScenarios.MyCouchStore)]
+        public void Query_When_Key_is_specified_using_custom_query_parameters_Then_the_matching_row_is_returned()
+        {
+            var artist = ArtistsById[2];
+            var query = new Query(ClientTestData.Views.ArtistsAlbumsViewId)
+                .Configure(q => q.CustomQueryParameters(new Dictionary<string, object>
+                {
+                    ["key"] = $"\"{artist.Name}\""
+                }));
+
+            var values = SUT.QueryAsync(query)
+                .Result
+                .OrderBy(r => r.Id)
+                .Select(r => r.Value)
+                .ToArray();
+
+            values.ShouldBeEquivalentTo(new[] { DbClient.Serializer.Serialize(artist.Albums) });
         }
     }
 }

--- a/source/tests/MyCouch.UnitTests/MyCouch.UnitTests.projitems
+++ b/source/tests/MyCouch.UnitTests/MyCouch.UnitTests.projitems
@@ -34,6 +34,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Net\BasicAuthStringTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Net\ConnectionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)QueryConfigurationTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)QueryTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\QueryShowRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\QueryViewRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\DocumentSerializationTests.cs" />

--- a/source/tests/MyCouch.UnitTests/QueryTests.cs
+++ b/source/tests/MyCouch.UnitTests/QueryTests.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace MyCouch.UnitTests
+{
+    public class QueryTests : UnitTestsOf<Query>
+    {
+        public QueryTests()
+        {
+            SUT = new Query("foodesigndoc", "barshowname");
+        }              
+
+        [Fact]
+        public void When_AdditionalQueryParameters_are_null_It_returns_false_for_HasAdditionalQueryParameters()
+        {
+            SUT.CustomQueryParameters = null;
+
+            SUT.HasCustomQueryParameters.Should().BeFalse();
+        }
+
+        [Fact]
+        public void When_AdditionalQueryParameters_are_empty_It_returns_false_for_HasAdditionalQueryParameters()
+        {
+            SUT.CustomQueryParameters = new Dictionary<string, object>();
+
+            SUT.HasCustomQueryParameters.Should().BeFalse();
+        }
+
+        [Fact]
+        public void When_AdditionalQueryParameters_are_specified_It_returns_true_for_HasAdditionalQueryParameters()
+        {
+            SUT.CustomQueryParameters = new Dictionary<string, object>
+            {
+                {"foo", new {bar = "bar"}}
+            };
+
+            SUT.HasCustomQueryParameters.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
When I use QueryAsync with custom query parameters an exception is thrown "Exception thrown: 'System.NullReferenceException' in MyCouch.Net45.dll".

I use this method from MyCouchStore. When I set query parameters by method CustomQueryParameters it is not set in Query object but parameter HasCustomQueryParameters is set on true. It causes the error in QueryAsync method.