### PR TITLE
New default value for ConnectionInfo.UseProxy : true

### DIFF
--- a/source/projects/MyCouch/ConnectionInfo.cs
+++ b/source/projects/MyCouch/ConnectionInfo.cs
@@ -31,7 +31,7 @@ namespace MyCouch
         public BasicAuthString BasicAuth { get; set; }
         public bool AllowAutoRedirect { get; set; } = false;
         public bool ExpectContinue { get; set; } = false;
-        public bool UseProxy { get; set; } = false;
+        public bool UseProxy { get; set; } = true;
 
         protected ConnectionInfo(Uri address)
         {


### PR DESCRIPTION
* fix MyCouch proxy compatibility according to default value of HttpClientHandler.UseProxy (true).