### PR TITLE
Support Document revisions

### DIFF
--- a/source/projects/MyCouch/HttpRequestFactories/GetDocumentHttpRequestFactory.cs
+++ b/source/projects/MyCouch/HttpRequestFactories/GetDocumentHttpRequestFactory.cs
@@ -22,6 +22,7 @@ namespace MyCouch.HttpRequestFactories
 
             urlParams.AddIfNotNullOrWhiteSpace("rev", request.Rev);
             urlParams.AddIfTrue("conflicts", request.Conflicts);
+            urlParams.AddIfTrue("revs", request.Revisions);
 
             return string.Format("/{0}{1}", new UrlSegment(request.Id), new QueryString(urlParams));
         }

--- a/source/projects/MyCouch/Requests/GetDocumentRequest.cs
+++ b/source/projects/MyCouch/Requests/GetDocumentRequest.cs
@@ -7,6 +7,7 @@ namespace MyCouch.Requests
         public string Id { get; private set; }
         public string Rev { get; private set; }
         public bool? Conflicts { get; set; }
+        public bool? Revisions { get; set; }
 
         public GetDocumentRequest(string id, string rev = null)
         {

--- a/source/projects/MyCouch/Responses/DocumentResponse.cs
+++ b/source/projects/MyCouch/Responses/DocumentResponse.cs
@@ -15,6 +15,15 @@ namespace MyCouch.Responses
         [JsonProperty(JsonScheme.Conflicts)]
         public string[] Conflicts { get; set; }
 
+        [JsonProperty(JsonScheme.Revisions)]
+        public RevisionList Revisions { get; set; }        
+
+        public class RevisionList
+        {
+            public string[] Ids { get; set; }
+            public int Start { get; set; }
+        }
+
         public override string ToStringDebugVersion()
         {
             return string.Format("{1}{0}Id: {2}{0}Rev: {3}",

--- a/source/projects/MyCouch/Responses/JsonScheme.cs
+++ b/source/projects/MyCouch/Responses/JsonScheme.cs
@@ -18,6 +18,7 @@
         public const string LastSeq = "last_seq";
         public const string TotalRows = "total_rows";
         public const string Conflicts = "_conflicts";
+        public const string Revisions = "_revisions";
 
         public const string LocalId = "_local_id";
         public const string NoChanges = "no_changes";

--- a/source/projects/MyCouch/Responses/Materializers/DocumentResponseMaterializer.cs
+++ b/source/projects/MyCouch/Responses/Materializers/DocumentResponseMaterializer.cs
@@ -35,6 +35,7 @@ namespace MyCouch.Responses.Materializers
                 response.Id = jt[JsonScheme._Id]?.Value<string>();
                 response.Rev = jt[JsonScheme._Rev]?.Value<string>();
                 response.Conflicts = jt[JsonScheme.Conflicts]?.Values<string>().ToArray();
+                response.Revisions = jt[JsonScheme.Revisions]?.Value<DocumentResponse.RevisionList>();
 
                 SetMissingIdFromRequestUri(response, httpResponse.RequestMessage);
                 SetMissingRevFromResponseHeaders(response, httpResponse.Headers);

--- a/source/projects/MyCouch/Responses/Materializers/DocumentResponseMaterializer.cs
+++ b/source/projects/MyCouch/Responses/Materializers/DocumentResponseMaterializer.cs
@@ -35,7 +35,7 @@ namespace MyCouch.Responses.Materializers
                 response.Id = jt[JsonScheme._Id]?.Value<string>();
                 response.Rev = jt[JsonScheme._Rev]?.Value<string>();
                 response.Conflicts = jt[JsonScheme.Conflicts]?.Values<string>().ToArray();
-                response.Revisions = jt[JsonScheme.Revisions]?.Value<DocumentResponse.RevisionList>();
+                response.Revisions = jt[JsonScheme.Revisions]?.ToObject<DocumentResponse.RevisionList>();
 
                 SetMissingIdFromRequestUri(response, httpResponse.RequestMessage);
                 SetMissingRevFromResponseHeaders(response, httpResponse.Headers);

--- a/source/tests/IntegrationTests/CoreTests/DocumentsTests.cs
+++ b/source/tests/IntegrationTests/CoreTests/DocumentsTests.cs
@@ -26,6 +26,20 @@ namespace IntegrationTests.CoreTests
         }
 
         [MyFact(TestScenarios.DocumentsContext)]
+        public void When_GET_of_document_when_including_revisions_It_returns_at_least_its_revision()
+        {
+            var postResponse = SUT.PostAsync(ClientTestData.Artists.Artist1Json).Result;
+            var postResponseRevId = postResponse.Rev.Split('-')[1];
+            var request = new GetDocumentRequest(postResponse.Id) { Revisions = true };
+
+            var response = SUT.GetAsync(request).Result;
+
+            response.Should().BeSuccessfulGet(postResponse.Id, postResponse.Rev);
+            response.Revisions.Should().NotBeNull();
+            response.Revisions.Ids.Should().NotBeNullOrEmpty().And.Contain(postResponseRevId);
+        }
+
+        [MyFact(TestScenarios.DocumentsContext)]
         public void When_HEAD_of_non_existing_document_The_response_is_empty()
         {
             var response = SUT.HeadAsync("fooId").Result;

--- a/source/tests/UnitTests/HttpRequestFactories/GetDocumentHttpRequestFactoryTests.cs
+++ b/source/tests/UnitTests/HttpRequestFactories/GetDocumentHttpRequestFactoryTests.cs
@@ -73,6 +73,21 @@ namespace UnitTests.HttpRequestFactories
                 });
         }
 
+        [Fact]
+        public void When_configured_with_revisions_It_yields_url_with_revs()
+        {
+            var request = CreateRequest();
+            request.Revisions = true;
+
+            WithHttpRequestFor(
+                request,
+                req =>
+                {
+                    req.RelativeUrl.ToTestUriFromRelative().AbsolutePath.Should().EndWith("/" + FakeId);
+                    req.RelativeUrl.ToTestUriFromRelative().Query.Should().Be("?revs=true");
+                });
+        }        
+
         protected virtual GetDocumentRequest CreateRequest(string id = FakeId, string rev = null)
         {
             return new GetDocumentRequest(id, rev);


### PR DESCRIPTION
This PR adds support for IDocument Revisions flag in order to return all revisions for a document.