### PR TITLE
Fixed issue #185 with attempt to read json from EmptyReadStream

### DIFF
--- a/source/projects/MyCouch/Serialization/DefaultSerializer.cs
+++ b/source/projects/MyCouch/Serialization/DefaultSerializer.cs
@@ -116,6 +116,11 @@ namespace MyCouch.Serialization
             {
                 using (var jsonReader = Configuration.ApplyConfigToReader(CreateReaderFor<T>(sr)))
                 {
+                    if (!jsonReader.Read())
+                    {
+                        return default(T);
+                    }
+
                     return InternalSerializer.Deserialize<T>(jsonReader);
                 }
             }
@@ -130,6 +135,11 @@ namespace MyCouch.Serialization
             {
                 using (var jsonReader = Configuration.ApplyConfigToReader(CreateReaderFor<T>(sr)))
                 {
+                    if (!jsonReader.Read())
+                    {
+                        return;
+                    }
+
                     InternalSerializer.Populate(jsonReader, item);
                 }
             }


### PR DESCRIPTION
Hi there! This PR is fixing issue #185 .

I did some tests and seems the 3-rd variant from what @alexandru-costan mentioned is the best in terms of performance and code compatibility, since there is no good way to modify StreamIsEmpty method to check for EmptyReadStream instance and/or checking that stream is empty without reading it. 
I've run integration tests, seems everything is ok now.

Internally we made temporary workaround for our project by extending DefaultSerializer class with patched methods. As soon as new nuget package will be available, we will switch to default implementation. Many thanks to you for such extensible architecture 😉