### PR TITLE
Fix: JSON strings are not escaped in URIs #188

### DIFF
--- a/source/projects/MyCouch/Serialization/DefaultSerializer.cs
+++ b/source/projects/MyCouch/Serialization/DefaultSerializer.cs
@@ -162,7 +162,7 @@ namespace MyCouch.Serialization
                 return null;
 
             if (value is string)
-                return string.Format("\"{0}\"", value as string);
+                return JsonConvert.ToString(value as string, '"', Configuration.Settings.StringEscapeHandling);
 
             if (value is Enum)
                 return string.Format("\"{0}\"", value);

--- a/source/tests/UnitTests/Serialization/DocumentSerializationTests.cs
+++ b/source/tests/UnitTests/Serialization/DocumentSerializationTests.cs
@@ -188,5 +188,16 @@ namespace UnitTests.Serialization
             json.Should().Contain("\"_id\":\"abc\"");
             json.Should().NotContain("\"modelFourId\":\"abc\"");
         }
+
+        [Fact]
+        public void When_serializing_entity_with_strings_needing_escaping_it_will_escape_them()
+        {
+            var model = new ModelOne { Id = @"some\id", Value = @"This ""Needs"" \escaping\\" };
+
+            var json = SUT.Serialize(model);
+
+            json.Should().Contain("\"_id\":\"some\\\\id\"");
+            json.Should().Contain("\"value\":\"This \\\"Needs\\\" \\\\escaping\\\\\\\\\"");
+        }
     }
 }

--- a/source/tests/UnitTests/Serialization/ToJsonTests.cs
+++ b/source/tests/UnitTests/Serialization/ToJsonTests.cs
@@ -1,0 +1,56 @@
+﻿using FluentAssertions;
+using MyCouch.EntitySchemes;
+using MyCouch.EntitySchemes.Reflections;
+using MyCouch.Serialization;
+using MyCouch.Serialization.Meta;
+using Xunit;
+
+namespace UnitTests.Serialization
+{
+    public class ToJsonWithLambdaPropertyFactoryTests : ToJsonTests
+    {
+        public ToJsonWithLambdaPropertyFactoryTests()
+        {
+            var entityReflector = new EntityReflector(new LambdaDynamicPropertyFactory());
+            var configuration = new SerializationConfiguration(new SerializationContractResolver());
+            SUT = new DefaultSerializer(configuration, new DocumentSerializationMetaProvider(), entityReflector);
+        }
+    }
+
+    public class ToJsonWithIlPropertyFactoryTests : ToJsonTests
+    {
+        public ToJsonWithIlPropertyFactoryTests()
+        {
+            var entityReflector = new EntityReflector(new IlDynamicPropertyFactory());
+            var configuration = new SerializationConfiguration(new SerializationContractResolver());
+            SUT = new DefaultSerializer(configuration, new DocumentSerializationMetaProvider(), entityReflector);
+        }
+    }
+
+    public abstract class ToJsonTests : UnitTestsOf<DefaultSerializer>
+    {
+        [Theory]
+        [InlineData("Test\"data", "\"Test\\\"data\"")]
+        [InlineData("Test\\data", "\"Test\\\\data\"")]
+        [InlineData("Test\\\\data", "\"Test\\\\\\\\data\"")]
+        public void ToJson_String_escapes_its_data(string input, string expected)
+        {
+            string serialized = SUT.ToJson(input);
+
+            serialized.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(new[] { "Test\"data" }, "[\"Test\\\"data\"]")]
+        [InlineData(new[] { "Test\\data" }, "[\"Test\\\\data\"]")]
+        [InlineData(new[] { "Test\\\\data" }, "[\"Test\\\\\\\\data\"]")]
+        [InlineData(new[] { "Test\"data", "Test\\data" }, "[\"Test\\\"data\",\"Test\\\\data\"]")]
+        [InlineData(new[] { "Test\\\\data", "Test\"data", "Test\\data" }, "[\"Test\\\\\\\\data\",\"Test\\\"data\",\"Test\\\\data\"]")]
+        public void ToJson_String_array_escapes_its_data(string[] inputs, string expected)
+        {
+            string serialized = SUT.ToJson(inputs);
+
+            serialized.Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
This pull request does the following:
1. Adds escaping to strings passed to `ISerializer.ToJson`.
2. Adds tests confirming both document serialization and general serialization perform the appropriate escaping on values.

Fixes #188.