### PR TITLE
Expose user defined proxy

### DIFF
--- a/source/projects/MyCouch/ConnectionInfo.cs
+++ b/source/projects/MyCouch/ConnectionInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Net;
 using EnsureThat;
 using MyCouch.Net;
 

--- a/source/projects/MyCouch/ConnectionInfo.cs
+++ b/source/projects/MyCouch/ConnectionInfo.cs
@@ -32,6 +32,7 @@ namespace MyCouch
         public bool AllowAutoRedirect { get; set; } = false;
         public bool ExpectContinue { get; set; } = false;
         public bool UseProxy { get; set; } = true;
+        public IWebProxy Proxy { get; set; } = null;
 
         protected ConnectionInfo(Uri address)
         {

--- a/source/projects/MyCouch/Net/Connection.cs
+++ b/source/projects/MyCouch/Net/Connection.cs
@@ -62,6 +62,7 @@ namespace MyCouch.Net
                 AllowAutoRedirect = connectionInfo.AllowAutoRedirect,
                 UseProxy = connectionInfo.UseProxy
             };
+            handler.Proxy = connectionInfo.Proxy;
 
             var client = new HttpClient(handler, true)
             {


### PR DESCRIPTION
Example:
```csharp
 var bootstrapper = new MyCouchClientBootstrapper {
    DbConnectionFn = connectionInfo => {
        connectionInfo.Proxy = new WebProxy("http://proxy:3128") {
            Credentials = new NetworkCredential("proxyUsername", "proxyPassword")
        };
        return new DbConnection(connectionInfo);
    }
};

var myCouchClient = new MyCouchClient("http://couchdb/database", bootstrapper);
```